### PR TITLE
changed the ingredients definition page to a more heirarchichal view

### DIFF
--- a/ffdjango/fftracker/fftracker/IngCategoryEnum.py
+++ b/ffdjango/fftracker/fftracker/IngCategoryEnum.py
@@ -1,0 +1,38 @@
+from enum import Enum
+
+class ParentCategory(Enum):
+    Fruits = 0
+    Vegetables = 1
+    Dairy = 2
+    Protein = 3
+    Grains = 4
+    Specialty = 5
+    Condiments = 6
+
+class SpecificCategory(Enum):
+    Melons = 0
+    Berries = 1
+    OtherFruits = 2
+    DarkgreenVegetables = 3
+    RedOrangeVegetables = 4
+    StarchyVegetables = 5
+    BeansPeasLentils = 6
+    OtherVegetables = 7
+    Milk = 8
+    Cheese = 9
+    Yogurt = 10
+    NonDairyCalciumAlternatives = 11
+    Meats = 12
+    Poultry = 13
+    Seafood = 14
+    Eggs = 15
+    NutsSeeds = 16
+    BeansPeasLentilsProtein = 17
+    WholeGrains = 18
+    RefinedGrains = 19
+    GlutenFree = 20
+    Vegan = 21
+    Allergies = 22
+    Sauces = 23
+    Seasonings = 24
+    Broths = 25

--- a/ffdjango/fftracker/fftracker/models.py
+++ b/ffdjango/fftracker/fftracker/models.py
@@ -8,6 +8,7 @@
 from django.db import models
 from django.contrib.auth.models import AbstractUser
 from django.core.validators import MinValueValidator, MaxValueValidator
+from .IngCategoryEnum import ParentCategory, SpecificCategory
 
 # AbstractUser Authorization model: Uses email as unique login
 #class CustomUser(AbstractUser):
@@ -302,6 +303,14 @@ class Ingredients(models.Model):
     class Meta:
         managed = True
         db_table = 'ingredients'
+
+class IngredientCategory(models.Model):
+    parent_category = models.CharField(max_length=50, choices=[(tag.name, tag.value) for tag in ParentCategory])
+    specific_category = models.CharField(max_length=50, choices=[(tag.name, tag.value) for tag in SpecificCategory])
+
+    class Meta:
+        managed = True
+        db_table = 'ingredient_category'
 
 # class IPLMealPlans(models.Model):
 #     m_id = models.AutoField(primary_key=True)

--- a/ffreact/src/App.js
+++ b/ffreact/src/App.js
@@ -48,6 +48,7 @@ import ShowServingsReport from './Reports/ShowServingsReport.js'
 import EbtReports from './Reports/EbtReports.js'
 import ProductReport from './Reports/ProductReport.js'
 import DietaryRestrictionsReport from './Reports/DietaryRestrictionsReport.js'
+import CategoryIngredientPage from './Ingredients/CategoryIngredientPage';
 
 
 // require("dotenv").config({path: `.env.${process.env.NODE_ENV}`})
@@ -267,6 +268,8 @@ const AppComponent = () => {
                         <Route path='/show-servings-report' element={<ShowServingsReport handlePageClick={handlePageClick} />}/>
                         <Route path='/product-report' element={<ProductReport handlePageClick={handlePageClick} />}/>
                         <Route path='/dietary-restrictions-report' element={<DietaryRestrictionsReport />} />
+                        <Route path="/ingredients" element={<IngredientDefinitionPage />} />
+                        <Route path="/ingredients/:categoryId" element={<CategoryIngredientPage />} />
                         <Route path='/under-construction' element={<UnderConstruction handlePageClick={handlePageClick}/>}/>
                         <Route path='/admin' element={
                             <AdminRoute isAdmin={loginState && loginState.isAdmin}>

--- a/ffreact/src/Ingredients/CategoryIngredientPage.js
+++ b/ffreact/src/Ingredients/CategoryIngredientPage.js
@@ -1,0 +1,43 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Box, Typography, Button } from '@mui/material';
+import axios from 'axios';
+
+const categoryNames = {
+    0: "Fruits",
+    1: "Vegetables",
+    2: "Dairy",
+    3: "Protein",
+    4: "Grains",
+    5: "Specialty",
+    6: "Condiments"
+};
+
+export default function CategoryIngredientPage() {
+    const { categoryId } = useParams();  // Get category ID from URL
+    const navigate = useNavigate();
+    const [ingredients, setIngredients] = useState([]);
+
+    useEffect(() => {
+        axios.get(`http://localhost:8000/api/ingredients/${categoryId}/`)
+            .then(response => setIngredients(response.data))
+            .catch(error => console.error("Error fetching ingredients:", error));
+    }, [categoryId]);
+
+    return (
+        <Box sx={{ p: 3 }}>
+            <Button variant="outlined" onClick={() => navigate('/ingredient-defs')}>Back to Categories</Button>
+            <Typography variant="h5" sx={{ mt: 2 }}>{categoryNames[categoryId]} Ingredients</Typography>
+
+            {ingredients.length > 0 ? (
+                <ul>
+                    {ingredients.map(ingredient => (
+                        <li key={ingredient.ing_name_id}>{ingredient.ing_name}</li>
+                    ))}
+                </ul>
+            ) : (
+                <Typography sx={{ mt: 2 }}>No ingredients found for this category.</Typography>
+            )}
+        </Box>
+    );
+}

--- a/ffreact/src/Ingredients/IngredientDefinitionPage.js
+++ b/ffreact/src/Ingredients/IngredientDefinitionPage.js
@@ -1,68 +1,51 @@
-import React, { useState, useEffect } from 'react'
-import axios from 'axios'
-import { Box } from '@mui/system';
-import NewModularDatagrid from '../components/NewModularDatagrid.js';
-import IngUnitTable from './IngUnitTable.js';
-import CellDialog from '../components/CellDialog.js'
-import { Typography } from '@mui/material';
-import { useGridApiContext, GridEditInputCell } from '@mui/x-data-grid';
-import IngredientDefForm from './IngredientDefForm.js';
-import EditableIngUnitTable from './EditableIngUnitTable.js';
+import React from 'react';
+import { Box, Typography, Grid, Paper, Button } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 
-// Ingredients List Component
-export default function IngredientDefinitionPage(props) {
-    const loginState = props.loginState.isAuthenticated ? props.loginState : {isAuthenticated: false};
+const categories = [
+    { name: 'Fruits', value: 0 },
+    { name: 'Vegetables', value: 1 },
+    { name: 'Dairy', value: 2 },
+    { name: 'Protein', value: 3 },
+    { name: 'Grains', value: 4 },
+    { name: 'Specialty', value: 5 },
+    { name: 'Condiments', value: 6 },
+];
 
-    // Structs
-    const [ingredientDefs, setIngredientDefs] = useState([]);
+export default function IngredientDefinitionPage() {
+    const navigate = useNavigate(); // Hook for navigation
 
-    if (ingredientDefs === undefined) {
-        return (
-            <>loading...</>
-        )
-    }
-    
-    // Columns and formatting to be sent to DataGrid 
-    const columns = [
-        { field: 'ing_name', headerName: 'Ingredient', width: 300, type: 'text', editable: true},
-        { field: 'ing_units', headerName: 'Units', width: 150, editable: true,
-            renderCell: (params) => {
-                if (params.value && params.value.length > 0)
-                    return <div style={{margin: 'auto'}}><CellDialog buttonText={'View Units'} dialogTitle={'Units'} component={<IngUnitTable ing_units={params.value}/>}/></div>
-                else 
-                    return <div style={{margin: 'auto'}}><Typography variant='p'>No Units</Typography></div>
-            },
-            renderEditCell: (params) => {
-                const api = useGridApiContext();
-                const updateCellValue = (fieldName, newValue) => {
-                    const {id, field} = params;
-                    api.current.setEditCellValue({id, field, value: newValue, debounceMs: 200})
-                }
-                return <div style={{margin: 'auto'}}><CellDialog buttonText={'Edit Units'} dialogTitle={'Edit Units'} component={<EditableIngUnitTable ing_units={params.value} updateEditForm={updateCellValue}/>}/></div>
-            },
-        },
-    ]
+    return (
+        <div className="table-div">
+            <Typography id="page-header" variant="h5" gutterBottom>
+                Ingredient Categories
+            </Typography>
 
-    // Page view; calls NewModularDataGrid
-    return(
-        <div class='table-div'>
-        <Typography id='page-header' variant='h5'>Ingredient Definitions</Typography>
-            <Box sx={{height: '70vh'}}>
-            <NewModularDatagrid 
-                loginState={loginState}
-                rows={ingredientDefs}
-                columns={columns}
-                apiEndpoint='ing-name-definitions'
-                // apiIP='localhost'
-                keyFieldName='ing_name_id'
-                entryName='Ingredient Definition'
-                searchField='ing_name'
-                searchLabel='Ingredient Names'
-                AddFormComponent={IngredientDefForm}
-            >
-            </NewModularDatagrid>
-        </Box>
-        {/* Add entry notice */}
+            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mt: 2 }}>
+                <Typography variant="h6">Select a Category</Typography>
+                <Grid container spacing={2} sx={{ mt: 2, maxWidth: 600 }}>
+                    {categories.map(category => (
+                        <Grid item xs={6} sm={4} key={category.value}>
+                            <Paper 
+                                elevation={3} 
+                                sx={{ p: 2, textAlign: 'center', cursor: 'pointer' }} 
+                                onClick={() => navigate(`/ingredients/${category.value}`)}
+                            >
+                                <Typography variant="body1">{category.name}</Typography>
+                            </Paper>
+                        </Grid>
+                    ))}
+                </Grid>
+
+                {/* View All Button */}
+                <Button 
+                    variant="contained" 
+                    sx={{ mt: 4 }} 
+                    onClick={() => navigate('/ingredients/all')}
+                >
+                    View All Ingredients
+                </Button>
+            </Box>
         </div>
-    )
+    );
 }

--- a/ffreact/src/components/NewModularDatagrid.js
+++ b/ffreact/src/components/NewModularDatagrid.js
@@ -235,11 +235,11 @@ export default function NewModularDatagrid(props) {
     }, [errorSBOpen])
 
     // Wait until table data is loaded to render datagrid
-    if (tableData === undefined ||  tableData.length === 0) {
-        return (
-            <>loading...</>
-        )
-    }
+   // if (tableData === undefined ||  tableData.length === 0) {
+    //    return (
+     //       <>loading...</>
+      //  )
+    //}
 
     // const [popoverAnchors, setPopoverAnchors] = useState({confirmDeleteAnchor: null, confirmCancelAnchor: null});
 
@@ -354,11 +354,11 @@ export default function NewModularDatagrid(props) {
         );
     }
     
-    if (tableData === undefined ||  tableData.length === 0)  {
-        return (
-            <>loading...</>
-        )
-    }
+   // if (tableData === undefined ||  tableData.length === 0)  {
+     //   return (
+       //     <>loading...</>
+        //)
+    //}
 
 
 


### PR DESCRIPTION
This pull request introduces new ingredient category enums, updates the Django models to include these categories, and adds new React components and routes to handle ingredient categories in the frontend.

### Backend Changes:
* Added `ParentCategory` and `SpecificCategory` enums to `IngCategoryEnum.py` to categorize ingredients.
* Updated `models.py` to import the new enums and added a new `IngredientCategory` model to represent ingredient categories in the database. [[1]](diffhunk://#diff-d0b77cc2a36e4b2302d9e703ffb63444bc5a33ee5961ed51ebd341907fc6fc22R11) [[2]](diffhunk://#diff-d0b77cc2a36e4b2302d9e703ffb63444bc5a33ee5961ed51ebd341907fc6fc22R307-R314)

### Frontend Changes:
* Added new routes in `App.js` to handle ingredient categories and specific category pages. [[1]](diffhunk://#diff-f58b334c5392f5fd0c59e62539879af157c768e67c13f7a76205496d6f46bb93R51) [[2]](diffhunk://#diff-f58b334c5392f5fd0c59e62539879af157c768e67c13f7a76205496d6f46bb93R271-R272)
* Created `CategoryIngredientPage.js` to display ingredients based on the selected category, fetching data from the backend.
* Updated `IngredientDefinitionPage.js` to provide a user interface for selecting ingredient categories and navigating to specific category pages.

### Miscellaneous Changes:
* Commented out the loading state check in `NewModularDatagrid.js` to prevent the component from returning a loading state. [[1]](diffhunk://#diff-458fb9b785bb75c54bc0423d40b3c18f8477e5e195be4d75cc696f131fb4db6eL238-R242) [[2]](diffhunk://#diff-458fb9b785bb75c54bc0423d40b3c18f8477e5e195be4d75cc696f131fb4db6eL357-R361)