### PR TITLE
this surely fixed the things the laast pr was supposed to

### DIFF
--- a/ffdjango/fftracker/fftracker/serializers.py
+++ b/ffdjango/fftracker/fftracker/serializers.py
@@ -136,15 +136,30 @@ class RecipesSerializer(serializers.ModelSerializer):
         read_only_fields = ('r_num',)
 
     def create(self, validated_data):
+        # Get the nested data
+        ingredients_data = self.initial_data.get('r_ingredients', [])
+        packaging_data = self.initial_data.get('r_packaging', [])
+        prep_instructions = self.initial_data.get('prep_instructions', [])
+        cooking_instructions = self.initial_data.get('cooking_instructions', [])
+        
         # Remove nested fields from validated_data
         for field in ['r_ingredients', 'r_packaging', 'prep_instructions', 'cooking_instructions']:
             validated_data.pop(field, None)
 
-        # Create base recipe
-        recipe = Recipes.objects.create(**validated_data)
+        # Create and save recipe first
+        recipe = Recipes.objects.create(
+            r_name=validated_data.get('r_name'),
+            r_servings=validated_data.get('r_servings', 1),
+            r_img_path=validated_data.get('r_img_path'),
+            r_img_upload=validated_data.get('r_img_upload'),
+            r_card_path=validated_data.get('r_card_path'),
+            r_card_upload=validated_data.get('r_card_upload'),
+            m_s=validated_data.get('m_s')
+        )
+        recipe.save()
 
-        # Create ingredients
-        for ingredient in self.initial_data.get('r_ingredients', []):
+        # Now create related objects after recipe is saved
+        for ingredient in ingredients_data:
             RecipeIngredients.objects.create(
                 ri_recipe_num=recipe,
                 ingredient_name=ingredient.get('ingredient_name', ''),
@@ -153,8 +168,7 @@ class RecipesSerializer(serializers.ModelSerializer):
                 prep=ingredient.get('prep', '')
             )
 
-        # Create packaging
-        for package in self.initial_data.get('r_packaging', []):
+        for package in packaging_data:
             RecipePackaging.objects.create(
                 rp_recipe_num=recipe,
                 pkg_type=package.get('pkg_type', ''),
@@ -162,8 +176,7 @@ class RecipesSerializer(serializers.ModelSerializer):
                 amt=package.get('amt')
             )
 
-        # Create prep instructions
-        for instruction in self.initial_data.get('prep_instructions', []):
+        for instruction in prep_instructions:
             RecipeInstructions.objects.create(
                 inst_recipe_num=recipe,
                 instruction_type='prep',
@@ -175,8 +188,7 @@ class RecipesSerializer(serializers.ModelSerializer):
                 substeps=instruction.get('substeps', [])
             )
 
-        # Create cooking instructions
-        for instruction in self.initial_data.get('cooking_instructions', []):
+        for instruction in cooking_instructions:
             RecipeInstructions.objects.create(
                 inst_recipe_num=recipe,
                 instruction_type='cook',


### PR DESCRIPTION
This pull request refactors the `create` method in the `ffdjango/fftracker/fftracker/serializers.py` file to improve clarity and maintainability by restructuring how nested data is handled during the creation of a recipe and its related objects. The changes focus on extracting nested data early, cleaning up the `validated_data`, and ensuring related objects are created after the main recipe is saved.

### Refactoring of the `create` method:

* Extracted nested data (`r_ingredients`, `r_packaging`, `prep_instructions`, `cooking_instructions`) into separate variables at the start of the `create` method for better readability and maintainability.
* Simplified the creation of the main `Recipes` object by explicitly specifying fields from `validated_data` and saving the recipe before creating related objects.
* Updated loops to use the extracted nested data variables (`ingredients_data`, `packaging_data`, `prep_instructions`, `cooking_instructions`) instead of repeatedly accessing `self.initial_data`. This ensures consistency and reduces redundant lookups. [[1]](diffhunk://#diff-47ca4779f078de50267e276c203fdda617af4659ed62b9c0319dfb0c751e7521L156-R179) [[2]](diffhunk://#diff-47ca4779f078de50267e276c203fdda617af4659ed62b9c0319dfb0c751e7521L178-R191)